### PR TITLE
Fix category feature.

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -64,15 +64,7 @@ exports.onCommand = function *() {
 					case 'category':
 					case 'categories':
 						if (option) {
-							catInfo = trivia.categories[option];
-							if (catInfo) {
-								tenant.setState('category', option);
-								tenant.setState('categoryId', catInfo.id);
-								tenant.setState('cluesCount', catInfo.count);
-								yield trivia.sendMessage(`The category has been set to <b>${option}</b>`);
-							} else {
-								yield trivia.sendMessage(`The <em>${option}</em> category could not be found; try specifying another.`);
-							}
+							yield* trivia.setCategory(option);
 						} else {
 							yield* trivia.showCategories(10);
 						}

--- a/lib/commander.js
+++ b/lib/commander.js
@@ -74,16 +74,7 @@ exports.onCommand = function *() {
 								yield trivia.sendMessage(`The <em>${option}</em> category could not be found; try specifying another.`);
 							}
 						} else {
-							endpoint = 'categories';
-							params = 'count=10&offset=' + Math.floor(Math.random()*1000);
-							msg = '<b>Categories</b><br />';
-
-							for (idx = 0; idx < payload.length; idx++) {
-								trivia.categories[payload[idx].title] = {id: payload[idx].id, count: payload[idx].clues_count};
-								msg += `${idx+1}. ${payload[idx].title}<br />`;
-							}
-
-							yield trivia.sendMessage(msg);
+							yield* trivia.showCategories(10);
 						}
 						break;
 

--- a/lib/commander.js
+++ b/lib/commander.js
@@ -46,7 +46,7 @@ exports.onCommand = function *() {
 			args = args ? args.trim() : null;
 
 			if (args) { // Specific trivia command
-				args = args.split(' ');
+				args = args.split(/\s(.+)?/);
 				command = args[0];
 				option = args[1];
 

--- a/lib/trivia.js
+++ b/lib/trivia.js
@@ -182,6 +182,28 @@ Trivia.prototype.checkAnswer = function* (guess) {
 };
 
 /**
+ * Retrieves a specific category.
+ *
+ * @param  {String} cat - The name of the category to retrieve.
+ * @yields {String|null} The response body if successful, otherwise `null`. This is a result of
+ *	attempting to send a room notification.
+ */
+ Trivia.prototype.setCategory = function* (cat) {
+ 	var tenant = this.tenants.getTenant(this.tenant.id),
+ 		catInfo;
+
+	catInfo = cats[cat];
+	if (catInfo) {
+		tenant.setState('category', cat);
+		tenant.setState('categoryId', catInfo.id);
+		tenant.setState('cluesCount', catInfo.count);
+		yield this.sendMessage(`The category has been set to <b>${cat}</b>`);
+	} else {
+		yield this.sendMessage(`The <em>${cat}</em> category could not be found; try specifying another.`);
+	}
+ };
+
+/**
  * Retrieves and displays a random set of categories.
  *
  * @param  {Number} count - The number of categories to retrieve.

--- a/lib/trivia.js
+++ b/lib/trivia.js
@@ -2,7 +2,7 @@ var fails = require('./fails.json'),
 	modes = require('./modes'),
 	utils = require('./utils');
 
-var cats = {};
+var cats = {}; // TOOD: temporary method for caching retrieved categories
 
 // Various configurion values
 var vowelThreshold = 0.4,
@@ -180,6 +180,28 @@ Trivia.prototype.checkAnswer = function* (guess) {
 		});
 	}
 };
+
+/**
+ * Retrieves and displays a random set of categories.
+ *
+ * @param  {Number} count - The number of categories to retrieve.
+ * @yields {String|null} The response body if successful, otherwise `null`. This is a result of
+ *	attempting to send a room notification.
+ */
+ Trivia.prototype.showCategories = function* (count) {
+ 	var endpoint = 'categories',
+		params = `count=${count}&offset=${Math.floor(Math.random()*1000)}`,
+		msg = '<b>Categories</b><br />',
+		payload = yield* utils.api(endpoint, params),
+		idx;
+
+	for (idx = 0; idx < payload.length; idx++) {
+		cats[payload[idx].title] = {id: payload[idx].id, count: payload[idx].clues_count};
+		msg += `${idx+1}. ${payload[idx].title}<br />`;
+	}
+
+ 	yield this.sendMessage(msg);
+ };
 
 /**
  * Generate and display a scoreboard.


### PR DESCRIPTION
This fixes #1 by moving category retrieval code to the appropriate module and actually performing the retrieval API call. Additionally, the category-setting command was incomplete as it only worked with single-word categories. The command parser has been updated to account for this.
